### PR TITLE
Update URLs in POM files

### DIFF
--- a/common.osgi/pom.xml
+++ b/common.osgi/pom.xml
@@ -26,7 +26,7 @@
 	<packaging>jar</packaging>
 
 	<name>Common Implementation objects for Feature Launcher and Runtime - OSGi API dependent</name>
-	<url>https://github.com/kentyou/feature-launcher-prototype</url>
+	<url>https://github.com/eclipse-osgi-technology/feature-launcher</url>
 
 	<properties>
 		<osgi.dependency.allowed>true</osgi.dependency.allowed>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -26,7 +26,7 @@
 	<packaging>jar</packaging>
 
 	<name>Common Implementation objects Feature Launcher - no OSGi framework dependency</name>
-	<url>https://github.com/kentyou/feature-launcher-prototype</url>
+	<url>https://github.com/eclipse-osgi-technology/feature-launcher</url>
 
 	<properties>
 		<featurelauncher.dependency.allowed>true</featurelauncher.dependency.allowed>

--- a/launch/all.lite/bin/pom.xml
+++ b/launch/all.lite/bin/pom.xml
@@ -15,7 +15,7 @@
 
 	<name>Lightweight OSGi Feature Launcher executable</name>
 	<description>An all in one CLI executable for the OSGi Feature Launcher using the Lite Resolver Artifact Repository implementation</description>
-	<url>https://github.com/kentyou/feature-launcher-prototype</url>
+	<url>https://github.com/eclipse-osgi-technology/feature-launcher</url>
 
 	<dependencies>
 		<dependency>

--- a/launch/all.lite/pom.xml
+++ b/launch/all.lite/pom.xml
@@ -26,7 +26,7 @@
 
 	<name>Lightweight OSGi Feature Launcher executable</name>
 	<description>An all in one CLI executable for the OSGi Feature Launcher using the Lite Resolver Artifact Repository implementation</description>
-	<url>https://github.com/kentyou/feature-launcher-prototype</url>
+	<url>https://github.com/eclipse-osgi-technology/feature-launcher</url>
 
 	<properties>
 		<osgi.dependency.allowed>true</osgi.dependency.allowed>

--- a/launch/all.maven/bin/pom.xml
+++ b/launch/all.maven/bin/pom.xml
@@ -15,7 +15,7 @@
 
 	<name>OSGi Feature Launcher executable - with Maven repo support</name>
 	<description>An all in one CLI executable for the OSGi Feature Launcher using the Maven Resolver Artifact Repository implementation</description>
-	<url>https://github.com/kentyou/feature-launcher-prototype</url>
+	<url>https://github.com/eclipse-osgi-technology/feature-launcher</url>
 
 	<dependencies>
 		<dependency>

--- a/launch/all.maven/pom.xml
+++ b/launch/all.maven/pom.xml
@@ -26,7 +26,7 @@
 
 	<name>OSGi Feature Launcher executable - with Maven repo support</name>
 	<description>An all in one CLI executable for the OSGi Feature Launcher using the Maven Resolver Artifact Repository implementation</description>
-	<url>https://github.com/kentyou/feature-launcher-prototype</url>
+	<url>https://github.com/eclipse-osgi-technology/feature-launcher</url>
 
 	<properties>
 		<osgi.dependency.allowed>true</osgi.dependency.allowed>

--- a/launch/cli.pico/pom.xml
+++ b/launch/cli.pico/pom.xml
@@ -25,7 +25,7 @@
 	<packaging>jar</packaging>
 
 	<name>Feature Launcher CLI using picocli - no OSGi Framework dependencies</name>
-	<url>https://github.com/kentyou/feature-launcher-prototype</url>
+	<url>https://github.com/eclipse-osgi-technology/feature-launcher</url>
 
 	<properties>
 		<featurelauncher.dependency.allowed>true</featurelauncher.dependency.allowed>

--- a/launch/launcher/pom.xml
+++ b/launch/launcher/pom.xml
@@ -25,7 +25,7 @@
 	<packaging>jar</packaging>
 
 	<name>Implementation of OSGi "160. Feature Launcher Service Specification" Launcher</name>
-	<url>https://github.com/kentyou/feature-launcher-prototype</url>
+	<url>https://github.com/eclipse-osgi-technology/feature-launcher</url>
 
 	<properties>
 		<osgi.dependency.allowed>true</osgi.dependency.allowed>

--- a/launch/pom.xml
+++ b/launch/pom.xml
@@ -26,7 +26,7 @@
 	<packaging>pom</packaging>
 
 	<name>Reactor for Feature Launcher Launch implementation code</name>
-	<url>https://github.com/kentyou/feature-launcher-prototype</url>
+	<url>https://github.com/eclipse-osgi-technology/feature-launcher</url>
 
 	<modules>
 		<module>spi</module>

--- a/launch/secondstage/pom.xml
+++ b/launch/secondstage/pom.xml
@@ -25,7 +25,7 @@
 	<packaging>jar</packaging>
 
 	<name>Implementation of OSGi "160. Feature Launcher Service Specification" - Second Stage Launcher</name>
-	<url>https://github.com/kentyou/feature-launcher-prototype</url>
+	<url>https://github.com/eclipse-osgi-technology/feature-launcher</url>
 
 	<properties>
 		<osgi.dependency.allowed>true</osgi.dependency.allowed>

--- a/launch/spi/pom.xml
+++ b/launch/spi/pom.xml
@@ -25,7 +25,7 @@
 	<packaging>jar</packaging>
 
 	<name>Feature Launcher Launch SPI - no OSGi Framework dependencies</name>
-	<url>https://github.com/kentyou/feature-launcher-prototype</url>
+	<url>https://github.com/eclipse-osgi-technology/feature-launcher</url>
 
 	<properties>
 		<featurelauncher.dependency.allowed>true</featurelauncher.dependency.allowed>

--- a/launch/tests/pom.xml
+++ b/launch/tests/pom.xml
@@ -26,7 +26,7 @@
 
 	<name>Feature Launcher - Launcher CLI Tests</name>
 	<description>Simple Tests for Launcher CLI packaging</description>
-	<url>https://github.com/kentyou/feature-launcher-prototype</url>
+	<url>https://github.com/eclipse-osgi-technology/feature-launcher</url>
 
 	<dependencies>
 		<dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -53,7 +53,7 @@
 	</repositories>
 
 	<name>Implementation of OSGi "160. Feature Launcher Service Specification"</name>
-	<url>https://github.com/kentyou/feature-launcher-prototype</url>
+	<url>https://github.com/eclipse-osgi-technology/feature-launcher</url>
 
 	<developers>
 		<developer>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 	<packaging>pom</packaging>
 
 	<name>Reactor for Feature Launcher Service Specification</name>
-	<url>https://github.com/kentyou/feature-launcher-prototype</url>
+	<url>https://github.com/eclipse-osgi-technology/feature-launcher</url>
 
 	<modules>
 		<module>parent</module>

--- a/repository/artifact.lite/pom.xml
+++ b/repository/artifact.lite/pom.xml
@@ -26,7 +26,7 @@
 
 	<name>OSGi Feature Launcher &quot;Lite&quot; Artifact Repository - no framework dependencies</name>
 	<description>A super lightweight artifact repository implementation with minimal features and footprint</description>
-	<url>https://github.com/kentyou/feature-launcher-prototype</url>
+	<url>https://github.com/eclipse-osgi-technology/feature-launcher</url>
 
 	<properties>
 		<featurelauncher.dependency.allowed>true</featurelauncher.dependency.allowed>

--- a/repository/artifact.maven/pom.xml
+++ b/repository/artifact.maven/pom.xml
@@ -25,7 +25,7 @@
 	<packaging>jar</packaging>
 
 	<name>OSGi Feature Launcher Maven Artifact Repository - no framework dependencie</name>
-	<url>https://github.com/kentyou/feature-launcher-prototype</url>
+	<url>https://github.com/eclipse-osgi-technology/feature-launcher</url>
 
 	<properties>
 		<featurelauncher.dependency.allowed>true</featurelauncher.dependency.allowed>

--- a/repository/common.osgi/pom.xml
+++ b/repository/common.osgi/pom.xml
@@ -25,7 +25,7 @@
 	<packaging>jar</packaging>
 
 	<name>Feature Launcher Repository - OSGi common code without framework dependencies</name>
-	<url>https://github.com/kentyou/feature-launcher-prototype</url>
+	<url>https://github.com/eclipse-osgi-technology/feature-launcher</url>
 
 	<properties>
 		<featurelauncher.dependency.allowed>true</featurelauncher.dependency.allowed>

--- a/repository/lite/pom.xml
+++ b/repository/lite/pom.xml
@@ -26,7 +26,7 @@
 
 	<name>&quot;Lite&quot; Repository - no OSGi dependencies</name>
 	<description>A super lightweight repository implementation with minimal features and footprint</description>
-	<url>https://github.com/kentyou/feature-launcher-prototype</url>
+	<url>https://github.com/eclipse-osgi-technology/feature-launcher</url>
 
 	<dependencies>
 		<dependency>

--- a/repository/maven.shading/pom.xml
+++ b/repository/maven.shading/pom.xml
@@ -25,7 +25,7 @@
 	<packaging>jar</packaging>
 
 	<name>Plugin for the maven-shade-plugin to shade maven resources</name>
-	<url>https://github.com/kentyou/feature-launcher-prototype</url>
+	<url>https://github.com/eclipse-osgi-technology/feature-launcher</url>
 
 	<dependencies>
 		<dependency>

--- a/repository/maven/pom.xml
+++ b/repository/maven/pom.xml
@@ -25,7 +25,7 @@
 	<packaging>jar</packaging>
 
 	<name>Feature Launcher &quot;Maven&quot; Repository - no OSGi dependencies</name>
-	<url>https://github.com/kentyou/feature-launcher-prototype</url>
+	<url>https://github.com/eclipse-osgi-technology/feature-launcher</url>
 
 	<dependencies>
 		<dependency>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -26,7 +26,7 @@
 	<packaging>pom</packaging>
 
 	<name>Reactor for Feature Launcher Repositories</name>
-	<url>https://github.com/kentyou/feature-launcher-prototype</url>
+	<url>https://github.com/eclipse-osgi-technology/feature-launcher</url>
 
 	<modules>
 		<module>spi</module>

--- a/repository/spi/pom.xml
+++ b/repository/spi/pom.xml
@@ -25,7 +25,7 @@
 	<packaging>jar</packaging>
 
 	<name>Feature Launcher Repository SPI - no OSGi dependencies</name>
-	<url>https://github.com/kentyou/feature-launcher-prototype</url>
+	<url>https://github.com/eclipse-osgi-technology/feature-launcher</url>
 
 	<dependencies>
 		<dependency>

--- a/repository/tests/pom.xml
+++ b/repository/tests/pom.xml
@@ -26,7 +26,7 @@
 
 	<name>Feature Launcher - Repository Tests</name>
 	<description>Simple Tests for Repository instances</description>
-	<url>https://github.com/kentyou/feature-launcher-prototype</url>
+	<url>https://github.com/eclipse-osgi-technology/feature-launcher</url>
 
 	<dependencies>
 		<dependency>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -26,7 +26,7 @@
 	<packaging>jar</packaging>
 
 	<name>Implementation for OSGi "160. Feature Launcher Service Specification" Runtime</name>
-	<url>https://github.com/kentyou/feature-launcher-prototype</url>
+	<url>https://github.com/eclipse-osgi-technology/feature-launcher</url>
 
 	<properties>
 		<osgi.dependency.allowed>true</osgi.dependency.allowed>


### PR DESCRIPTION
The URL entry in the pom files contained an old repository. This should point to the current home of the implementation at https://github.com/eclipse-osgi-technology/feature-launcher