### PR TITLE
javax.xml.stream.XMLInputFactory: Provider org.eclipse.osgi.technology.shaded.wstx.stax.WstxInputFactory not found

### DIFF
--- a/repository/maven/src/main/java/org/eclipse/osgi/technology/featurelauncher/repository/maven/AbstractMavenRepositoryImpl.java
+++ b/repository/maven/src/main/java/org/eclipse/osgi/technology/featurelauncher/repository/maven/AbstractMavenRepositoryImpl.java
@@ -26,6 +26,9 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Supplier;
 
+import com.ctc.wstx.stax.WstxEventFactory;
+import com.ctc.wstx.stax.WstxInputFactory;
+import com.ctc.wstx.stax.WstxOutputFactory;
 import org.apache.maven.internal.impl.resolver.MavenSessionBuilderSupplier;
 import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositorySystem;
@@ -175,5 +178,12 @@ abstract class AbstractMavenRepositoryImpl implements FileSystemRepository {
 		sessionBuilder.setLocalRepositoryManager(localRepositoryManager);
 
 		return sessionBuilder.build();
+	}
+
+	// https://github.com/apache/maven-shade-plugin/issues/255
+	static {
+		Class<WstxInputFactory> toStopMinimise1 =  WstxInputFactory.class;
+		Class<WstxEventFactory> toStopMinimise2 =  WstxEventFactory.class;
+		Class<WstxOutputFactory> toStopMinimise3 =  WstxOutputFactory.class;
 	}
 }


### PR DESCRIPTION
This is a rather specific workflow, where if you are loading an artifact (via the `MavenRepository`), and the artifact is a version of RELEASE, LATEST or  -SNAPSHOT (logic in `DefaultVersionResolver.resolveVersion`) and contains `maven-metadata.xml`,  then during resolution in `org.apache.maven.repository.internal.DefaultVersionResolver.readVersions` it will instantiate a MetadataStaxReader and then read.

The first thing read does is:
`XMLInputFactory factory = XMLInputFactory.newFactory();`

However due to the use of the maven.shading plugin with minimize = true the shaded output classes don't include the `WstxInputFactory`.

Even though in `META-INF/services/javax.xml.stream.XMLInputFactory` is:
`org.eclipse.osgi.technology.shaded.wstx.stax.WstxInputFactory`

I played around with the maven.shading plugin quite a bit, but I couldn't figure out how to configure it to not minimise the WstxInputFactory. So the result is my heavy-handed solution to just hard-code a reference 🤦‍♂️


Just for reference the is my stacktrace i was dealing with:
```
Caused by: java.util.ServiceConfigurationError: javax.xml.stream.XMLInputFactory: Provider org.eclipse.osgi.technology.shaded.wstx.stax.WstxInputFactory not found
    at java.util.ServiceLoader.fail (ServiceLoader.java:593)
    at java.util.ServiceLoader$LazyClassPathLookupIterator.nextProviderClass (ServiceLoader.java:1219)
    at java.util.ServiceLoader$LazyClassPathLookupIterator.hasNextService (ServiceLoader.java:1228)
    at java.util.ServiceLoader$LazyClassPathLookupIterator.hasNext (ServiceLoader.java:1273)
    at java.util.ServiceLoader$2.hasNext (ServiceLoader.java:1309)
    at java.util.ServiceLoader$3.hasNext (ServiceLoader.java:1393)
    at javax.xml.stream.FactoryFinder$1.run (FactoryFinder.java:304)
    at java.security.AccessController.doPrivileged (AccessController.java:319)
    at javax.xml.stream.FactoryFinder.findServiceProvider (FactoryFinder.java:293)
    at javax.xml.stream.FactoryFinder.find (FactoryFinder.java:264)
    at javax.xml.stream.FactoryFinder.find (FactoryFinder.java:210)
    at javax.xml.stream.XMLInputFactory.newFactory (XMLInputFactory.java:185)
    at org.eclipse.osgi.technology.shaded.maven.metadata.v4.MetadataStaxReader.read (MetadataStaxReader.java:367)
    at org.eclipse.osgi.technology.shaded.maven.repository.internal.DefaultVersionResolver.readVersions (DefaultVersionResolver.java:249)
    at org.eclipse.osgi.technology.shaded.maven.repository.internal.DefaultVersionResolver.resolveVersion (DefaultVersionResolver.java:178)
    at org.eclipse.osgi.technology.shaded.aether.internal.impl.DefaultArtifactResolver.resolve (DefaultArtifactResolver.java:278)
    at org.eclipse.osgi.technology.shaded.aether.internal.impl.DefaultArtifactResolver.resolveArtifacts (DefaultArtifactResolver.java:201)
    at org.eclipse.osgi.technology.shaded.aether.internal.impl.DefaultArtifactResolver.resolveArtifact (DefaultArtifactResolver.java:180)
    at org.eclipse.osgi.technology.shaded.aether.internal.impl.DefaultRepositorySystem.resolveArtifact (DefaultRepositorySystem.java:213)
    at org.eclipse.osgi.technology.featurelauncher.repository.maven.AbstractMavenRepositoryImpl.getArtifactPath (AbstractMavenRepositoryImpl.java:124)
    at org.eclipse.osgi.technology.featurelauncher.repository.maven.AbstractMavenRepositoryImpl.getArtifactData (AbstractMavenRepositoryImpl.java:89)
    at org.eclipse.osgi.technology.featurelauncher.repository.common.osgi.ArtifactRepositoryAdapter.getArtifact (ArtifactRepositoryAdapter.java:32)
    at org.eclipse.osgi.technology.featurelauncher.launch.secondstage.SecondStageLauncherImpl.getArtifact (SecondStageLauncherImpl.java:373)
    at org.eclipse.osgi.technology.featurelauncher.launch.secondstage.SecondStageLauncherImpl.installBundle (SecondStageLauncherImpl.java:347)
    at org.eclipse.osgi.technology.featurelauncher.launch.secondstage.SecondStageLauncherImpl.installBundle (SecondStageLauncherImpl.java:336)
    at org.eclipse.osgi.technology.featurelauncher.launch.secondstage.SecondStageLauncherImpl.installBundles (SecondStageLauncherImpl.java:324)
    at org.eclipse.osgi.technology.featurelauncher.launch.secondstage.SecondStageLauncherImpl.launchFramework (SecondStageLauncherImpl.java:108)
    at org.eclipse.osgi.technology.featurelauncher.launch.launcher.FeatureLauncherImpl$LaunchBuilderImpl.launchFramework (FeatureLauncherImpl.java:286)
    at com.kentyou.ocx2024.featurelauncher.demo2.API_Launcher.main (API_Launcher.java:48)
    at org.codehaus.mojo.exec.ExecJavaMojo.doMain (ExecJavaMojo.java:375)
    at org.codehaus.mojo.exec.ExecJavaMojo.doExec (ExecJavaMojo.java:364)
    at org.codehaus.mojo.exec.ExecJavaMojo.lambda$execute$0 (ExecJavaMojo.java:286)
    at java.lang.Thread.run (Thread.java:1583)
```