### PR TITLE
Reduce error logging

### DIFF
--- a/repository/maven/src/main/java/org/eclipse/osgi/technology/featurelauncher/repository/maven/AbstractMavenRepositoryImpl.java
+++ b/repository/maven/src/main/java/org/eclipse/osgi/technology/featurelauncher/repository/maven/AbstractMavenRepositoryImpl.java
@@ -128,7 +128,7 @@ abstract class AbstractMavenRepositoryImpl implements FileSystemRepository {
 			}
 
 		} catch (ArtifactResolutionException e) {
-			LOG.error(String.format("Error getting artifact ID '%s'", id.toString()), e);
+			LOG.warn(String.format("Unable to get artifact ID '%s'", id.toString()));
 		}
 
 		return null;


### PR DESCRIPTION
In my scenario I have multiple bundles in a feature that are in multiple _different_ repos. Currently when loading the feature bundle I'm getting a full stack-trace error every time the MavenRepoImpl is unable to find the artifact, even though the artifact is loaded successfully by a subsequent repo. Which is causing a lot of errors in my logs, that aren't errors.