### PR TITLE
Add hash.checker into launchers - always be able to check hash of bundle

### DIFF
--- a/launch/all.lite/pom.xml
+++ b/launch/all.lite/pom.xml
@@ -79,6 +79,11 @@
       <artifactId>nanojson</artifactId>
       <version>1.10</version>
     </dependency>
+		<dependency>
+			<groupId>org.eclipse.osgi-technology.featurelauncher.extensions</groupId>
+			<artifactId>hash.checker</artifactId>
+			<version>${project.version}</version>
+		</dependency>
 
 		<!-- default OSGi framework -->
 <!--		<dependency>
@@ -135,6 +140,7 @@
 									<include>org.eclipse.osgi-technology.featurelauncher.launch:spi</include>
                   <include>org.eclipse.osgi-technology.featurelauncher.featureservice:base</include>
                   <include>com.grack:nanojson</include>
+									<include>org.eclipse.osgi-technology.featurelauncher.extensions:hash.checker</include>
 									<include>org.osgi:org.osgi.service.feature</include>
 									<include>org.osgi:org.osgi.service.featurelauncher</include>
 									<include>org.slf4j:slf4j-api</include>

--- a/launch/all.maven/pom.xml
+++ b/launch/all.maven/pom.xml
@@ -78,6 +78,12 @@
 			<artifactId>picocli</artifactId>
 		</dependency>
 		
+		<dependency>
+			<groupId>org.eclipse.osgi-technology.featurelauncher.extensions</groupId>
+			<artifactId>hash.checker</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
 		<!-- These are nested for second stage launch-->
 		<dependency>
 			<groupId>${project.groupId}</groupId>
@@ -141,6 +147,7 @@
 									<include>info.picocli:picocli</include>
 									<include>org.eclipse.osgi-technology.featurelauncher.featureservice:base</include>
 									<include>com.grack:nanojson</include>
+									<include>org.eclipse.osgi-technology.featurelauncher.extensions:hash.checker</include>
 									<include>org.glassfish:jakarta.json</include>
 									<include>org.osgi:org.osgi.service.feature</include>
 									<include>org.osgi:org.osgi.service.featurelauncher</include>


### PR DESCRIPTION
@maho7791 am i right that you need this to match the BSI requiroments of pin anf check versions?
or is just the version and gav enough